### PR TITLE
Update for new version of PYX

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,6 @@ WORKDIR /opt
 RUN git clone https://github.com/ajanata/PretendYoureXyzzy.git
 WORKDIR PretendYoureXyzzy
 RUN cp build.properties.example build.properties
-RUN mvn clean package war:exploded
+RUN mvn clean package war:exploded -Dmaven.buildNumber.doCheck=false -Dmaven.buildNumber.doUpdate=false
 EXPOSE 8080
-CMD mvn jetty:run
+CMD mvn jetty:run -Dmaven.buildNumber.doCheck=false -Dmaven.buildNumber.doUpdate=false


### PR DESCRIPTION
The updated version of PYX requires some extra maven options to build (see the PYX readme https://github.com/ajanata/PretendYoureXyzzy)